### PR TITLE
UNI-69754 show FBX version in Maya multi publish

### DIFF
--- a/hooks/tk-maya/tk-multi-publish2/basic/collector.py
+++ b/hooks/tk-maya/tk-multi-publish2/basic/collector.py
@@ -159,6 +159,7 @@ class MayaSessionCollectorExt(HookBaseClass):
             parent_item,
             fbx_path
         )
+        item._set_name(os.path.basename(fbx_path))
         
         if publish_template:
             item.properties["publish_template"] = publish_template


### PR DESCRIPTION
set name to include the version number after creating the item, otherwise cuts out the version number from the display name